### PR TITLE
Update mouseLeft onMouseEnter

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ export default function useMouseLeave() {
 
   // Start tracking the pointer when it enters our element
   const handleMouseEnter = useRef(() => {
+    setMouseLeft(false);
     window.addEventListener('mousemove', handleMouseMove);
   }).current;
 


### PR DESCRIPTION
There is an issue where if you move the cursor fast and around the edge of your element, you can trigger onMouseEnter (while mouseLeft is true) which in turns adds the mousemove event, but when mousemove calculates the mouse position it is actually in a place where it is still left, so mousemove was added to the window and is continuing to be triggered as you move around the page until you return to the element and reset the handler.

By setting mouseLeft to false onMouseEnter you can avoid this runaway case because when mousemove is triggered after onMouseEnter it will switch it from false to true and this will trigger the useEffect to properly remove the event listener.

![Kapture 2021-12-03 at 12 38 05](https://user-images.githubusercontent.com/26290074/144647716-98c8ea47-1ce9-4e62-8464-a5990d2d7d69.gif)

I think the easiest way to put it is that the order of events where you enter, then the very next event is a mousemove to outside the element triggers the runaway case.